### PR TITLE
docs: add label taxonomy and milestone map to PR workflow

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,7 +6,7 @@
 
 ## Current System State
 
-Repository initialized. Codebase empty. Architecture, design, and roadmap documents are locked in `docs/`. Agent-context files (`CLAUDE.md`, `llms.txt`, `.agent-plan.md`) are initialized. Branch/PR workflow rules are locked in `CLAUDE.md` and enforced via `.git/hooks/pre-push`.
+Repository initialized. Codebase empty. Architecture, design, and roadmap documents are locked in `docs/`. Agent-context files (`CLAUDE.md`, `llms.txt`, `.agent-plan.md`) are initialized. Branch/PR workflow rules (including label taxonomy and milestone map) are locked in `CLAUDE.md` and enforced via `.git/hooks/pre-push`. GitHub labels and milestones (v0.1–v1.0) are created.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,36 @@
 3. Do the work; commit to the branch.
 4. Update `.agent-plan.md` to reflect project state *after* the PR merges; commit that update to the same branch (same PR).
 5. Open a PR against `main` on GitHub with a detailed description.
+6. Apply the appropriate **labels** to the PR (create new ones if none fit — see label taxonomy below).
+7. Assign the PR to the appropriate **milestone** (create a new one on GitHub if none fits).
 
 Never use `git push origin main`, `git push --force`, or any variant that targets `main` directly.
+
+### Label taxonomy
+
+**Type** (one required):
+`type: feature` · `type: bugfix` · `type: docs` · `type: test` · `type: refactor` · `type: ci` · `type: chore`
+
+**Layer** (one or more, when touching package code):
+`layer: core` · `layer: narrative` · `layer: schema` · `layer: structure` · `layer: mechanisms` · `layer: simulation` · `layer: render` · `layer: exposure` · `layer: validation` · `layer: cli` · `layer: api` · `layer: recipes`
+
+**Status** (optional):
+`status: in progress` · `status: needs review` · `status: blocked`
+
+Existing labels that predate this taxonomy: `bug` · `documentation` · `enhancement` · `good first issue` · `help wanted` · `foundation` — use when appropriate.
+
+### Milestone map
+
+| Milestone | Covers | Roadmap |
+|---|---|---|
+| v0.1.0 — Repo & CLI skeleton | M0 | Foundation, CI, package scaffold |
+| v0.2.0 — First end-to-end world | M1–M3 | Config/recipe, narrative, schema |
+| v0.3.0 — Motif variability + exposure modes | M4–M6 | Structure, mechanisms, exposure |
+| v0.4.0 — Polished relational output + task export | M7–M10 | Simulation, observation, render, task |
+| v0.5.0 — CLI-complete release candidate | M11–M13 | CLI, validation harness |
+| v1.0.0 — Polished OSS release | M14–M15 | Sample data, notebooks, docs polish |
+
+If work spans multiple milestones, assign to the earliest one it unblocks.
 
 ---
 


### PR DESCRIPTION
## Summary

- Extends the Branch & PR Workflow section in `CLAUDE.md` with two new required steps: apply labels and assign to a milestone
- Adds a full label taxonomy (type / layer / status groups) and a milestone map table directly in `CLAUDE.md` so the rules are self-contained
- Creates all labels and milestones on GitHub

## Labels created (22)

**Type** — `type: feature`, `type: bugfix`, `type: docs`, `type: test`, `type: refactor`, `type: ci`, `type: chore`

**Layer** — one per package module: `layer: core`, `layer: narrative`, `layer: schema`, `layer: structure`, `layer: mechanisms`, `layer: simulation`, `layer: render`, `layer: exposure`, `layer: validation`, `layer: cli`, `layer: api`, `layer: recipes`

**Status** — `status: in progress`, `status: needs review`, `status: blocked`

## Milestones created (6)

| Milestone | Roadmap scope |
|---|---|
| v0.1.0 — Repo & CLI skeleton | M0 |
| v0.2.0 — First end-to-end world | M1–M3 |
| v0.3.0 — Motif variability + exposure modes | M4–M6 |
| v0.4.0 — Polished relational output + task export | M7–M10 |
| v0.5.0 — CLI-complete release candidate | M11–M13 |
| v1.0.0 — Polished OSS release | M14–M15 |

## Note

This PR is stacked on top of #1 (branch/PR workflow rules). It should be merged after #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)