### PR TITLE
Fix approved pr-agent-context refresh runs

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,7 +6,7 @@
 
 ## Current System State
 
-**v0.5.0 in progress — Milestones 7–11 complete, v4 dataset shipped.** Full simulation engine + render/bundle + exposure filtering + CLI commands + validation harness implemented. v4 engine changes + build pipeline merged (PR #21). v4 dataset generated and validated. 609 tests passing.
+**v0.5.0 in progress — Milestones 7–11 complete, v4 dataset shipped.** Full simulation engine + render/bundle + exposure filtering + CLI commands + validation harness implemented. v4 engine changes + build pipeline merged (PR #21). v4 dataset generated and validated. PR-agent refresh fallback wiring fixed for bot-authored reviews. 609 tests passing.
 
 ---
 

--- a/.github/workflows/pr-agent-context-refresh-dispatcher.yml
+++ b/.github/workflows/pr-agent-context-refresh-dispatcher.yml
@@ -163,6 +163,8 @@ jobs:
                     pull_request_number: String(pr.number),
                     pull_request_head_sha: pr.head.sha,
                     pull_request_base_sha: pr.base.sha,
+                    trigger_event_name: 'schedule',
+                    trigger_event_action: '',
                   },
                 });
 

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -3,7 +3,7 @@ run-name: >-
   ${{
     github.event_name == 'workflow_dispatch' &&
     format(
-      'scheduled refresh PR #{0} @ {1}',
+      'dispatch refresh PR #{0} @ {1}',
       github.event.inputs.pull_request_number,
       github.event.inputs.pull_request_head_sha
     ) ||
@@ -52,7 +52,8 @@ on:
         type: string
 
 # SHA-aware concurrency: workflow_dispatch runs key on PR+SHA so same-PR/different-SHA
-# dispatches are not cancelled, but duplicate dispatches for the same PR+SHA are.
+# dispatches can run independently. Direct event-triggered refreshes cancel older in-flight runs;
+# workflow_dispatch refreshes share the PR+SHA group but are allowed to finish instead of being cancelled.
 concurrency:
   group: >-
     pr-agent-context-refresh-${{

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -1,4 +1,23 @@
 name: PR agent context refresh
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'scheduled refresh PR #{0} @ {1}',
+      github.event.inputs.pull_request_number,
+      github.event.inputs.pull_request_head_sha
+    ) ||
+    github.event_name == 'pull_request_review' &&
+    format('review refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'pull_request_review_comment' &&
+    format('review-comment refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'check_run' &&
+    format(
+      'check refresh {0}',
+      github.event.check_run.pull_requests[0].number || github.event.check_run.head_sha
+    ) ||
+    github.workflow
+  }}
 
 on:
   pull_request_review:
@@ -21,6 +40,16 @@ on:
         description: Base SHA of the PR
         required: true
         type: string
+      trigger_event_name:
+        description: Synthetic trigger event name used in rendered metadata
+        required: false
+        default: workflow_dispatch
+        type: string
+      trigger_event_action:
+        description: Synthetic trigger event action used in rendered metadata
+        required: false
+        default: ""
+        type: string
 
 # SHA-aware concurrency: workflow_dispatch runs key on PR+SHA so same-PR/different-SHA
 # dispatches are not cancelled, but duplicate dispatches for the same PR+SHA are.
@@ -34,7 +63,7 @@ concurrency:
       github.event.check_run.head_sha ||
       github.sha
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -45,7 +74,10 @@ jobs:
   pr-agent-context-refresh:
     name: PR agent context refresh
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.pull_request_number != '' &&
+       github.event.inputs.pull_request_base_sha != '' &&
+       github.event.inputs.pull_request_head_sha != '') ||
       (github.event_name == 'pull_request_review' &&
        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review_comment' &&
@@ -59,6 +91,11 @@ jobs:
     with:
       tool_ref: v4
       execution_mode: refresh
+      trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
+      trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}
+      pull_request_number_override: ${{ github.event.inputs.pull_request_number || '' }}
+      pull_request_head_sha_override: ${{ github.event.inputs.pull_request_head_sha || '' }}
+      pull_request_base_sha_override: ${{ github.event.inputs.pull_request_base_sha || '' }}
       publish_mode: append
       include_review_comments: true
       include_outdated_review_threads: true
@@ -67,10 +104,8 @@ jobs:
       include_patch_coverage: true
       target_patch_coverage: "100"
       coverage_artifact_prefix: pr-agent-context-coverage
+      coverage_source_workflows: CI
       enable_cross_run_coverage_lookup: true
       wait_for_reviews_to_settle: true
       publish_all_clear_comments_in_refresh: false
       debug_artifacts: true
-      pull_request_number: ${{ inputs.pull_request_number || '' }}
-      pull_request_head_sha: ${{ inputs.pull_request_head_sha || '' }}
-      pull_request_base_sha: ${{ inputs.pull_request_base_sha || '' }}


### PR DESCRIPTION
## Summary

Fixes the `pr-agent-context` refresh path used after Copilot or other bot-authored reviews land on an open PR.

This specifically addresses the manual **Approve Run** regression seen on PR #25: GitHub did create a second attempt after approval, but the refresh workflow failed at reusable-workflow validation with `startup_failure` before any job existed.

The refresh workflow already had direct review triggers and a scheduled dispatcher, but the workflow call still passed the old `pull_request_*` input names into `shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4`. The reusable workflow expects the `*_override` inputs, so manually approved bot-triggered refresh attempts could fail at workflow startup before any job existed.

## Changes

- Pass `pull_request_number_override`, `pull_request_head_sha_override`, and `pull_request_base_sha_override` to the reusable `pr-agent-context` workflow.
- Add `trigger_event_name` and `trigger_event_action` dispatch inputs, then forward them as trigger metadata overrides.
- Make scheduled `workflow_dispatch` refreshes non-cancelling so fallback dispatches do not churn in-flight runs.
- Add a `run-name` that makes scheduled/manual refresh runs easy to dedupe and inspect.
- Set `coverage_source_workflows: CI` for cross-run coverage lookup.
- Send `schedule` trigger metadata from the dispatcher.
- Update `.agent-plan.md` with the expected post-merge state.

## Validation

- `python` YAML parse of both refresh workflow files passed.
- `git diff --check` passed.
- Commit hooks passed: trim trailing whitespace, end-of-file fixer, YAML check, merge-conflict check.

## Notes

`actionlint` is not installed in the local environment, so validation used YAML parsing and the repository pre-commit YAML check.
