### PR TITLE
ci(site): bump deploy-docs actions to Node 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,11 +25,11 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: website/package-lock.json
 


### PR DESCRIPTION
Silences the Node.js 20 deprecation warning from the deploy-docs workflow.

- `actions/checkout@v4` → `@v4.2.2`
- `actions/setup-node@v4` → `@v4.4.0`, node-version `20` → `24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)