### PR TITLE
fix(publish): publish HF dataset under shaypal5 personal account

### DIFF
--- a/scripts/publish_hf.py
+++ b/scripts/publish_hf.py
@@ -128,7 +128,7 @@ from package_hf_release import (  # noqa: E402
 # Repo identity
 # ---------------------------------------------------------------------------
 
-HF_ORG: Final[str] = "leadforge"
+HF_ORG: Final[str] = "shaypal5"
 REPO_IDS: Final[dict[str, str]] = {
     "public": f"{HF_ORG}/leadforge-lead-scoring-v1",
     "instructor": f"{HF_ORG}/leadforge-lead-scoring-v1-instructor",


### PR DESCRIPTION
The `leadforge` org doesn't exist on HuggingFace. Switches `HF_ORG` from `"leadforge"` to `"shaypal5"` so the publish script targets the correct namespace.

Dataset already uploaded privately at https://huggingface.co/datasets/shaypal5/leadforge-lead-scoring-v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)