### PR TITLE
fix(release): remove Kaggle-invalid keywords from default keyword set

### DIFF
--- a/release/_preview_committed/kaggle.html
+++ b/release/_preview_committed/kaggle.html
@@ -115,13 +115,8 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   ],
   "isAccessibleForFree": true,
   "keywords": [
-    "b2b",
     "classification",
-    "crm",
     "education",
-    "lead-scoring",
-    "saas",
-    "synthetic-data",
     "tabular"
   ],
   "license": "https://opensource.org/licenses/MIT",
@@ -1471,7 +1466,7 @@ Profiles: <a href="https://huggingface.co/shaypal5">HuggingFace</a> · <a href="
   </ul>
 </section>
 <footer class="dataset-footer">
-  <div class="dataset-footer__keywords"><span class="chip">b2b</span> <span class="chip">classification</span> <span class="chip">crm</span> <span class="chip">education</span> <span class="chip">lead-scoring</span> <span class="chip">saas</span> <span class="chip">synthetic-data</span> <span class="chip">tabular</span></div>
+  <div class="dataset-footer__keywords"><span class="chip">classification</span> <span class="chip">education</span> <span class="chip">tabular</span></div>
   <div class="dataset-footer__license">License: MIT</div>
   <div class="dataset-footer__note">Local Kaggle publication-readiness preview rendered by scripts/preview_kaggle_page.py — not the live dataset page.</div>
 </footer>

--- a/release/kaggle/dataset-metadata.json
+++ b/release/kaggle/dataset-metadata.json
@@ -6,13 +6,8 @@
   "image": "dataset-cover-image.png",
   "isPrivate": false,
   "keywords": [
-    "b2b",
     "classification",
-    "crm",
     "education",
-    "lead-scoring",
-    "saas",
-    "synthetic-data",
     "tabular"
   ],
   "licenses": [

--- a/scripts/lint_platform_metadata.py
+++ b/scripts/lint_platform_metadata.py
@@ -56,9 +56,7 @@ HF_SPLIT_TO_FILE_SPLIT: Final[dict[str, str]] = {
     "validation": "valid",
     "test": "test",
 }
-REQUIRED_COMMON_TAGS: Final[frozenset[str]] = frozenset(
-    {"b2b", "crm", "lead-scoring", "synthetic-data", "tabular"}
-)
+REQUIRED_COMMON_TAGS: Final[frozenset[str]] = frozenset({"tabular"})
 EXPECTED_KAGGLE_KEYWORDS: Final[frozenset[str]] = frozenset(DEFAULT_KAGGLE_KEYWORDS)
 EXPECTED_HF_TAGS: Final[frozenset[str]] = frozenset(DEFAULT_HF_TAGS)
 REQUIRED_HF_TASK: Final[str] = "tabular-classification"

--- a/scripts/package_kaggle_release.py
+++ b/scripts/package_kaggle_release.py
@@ -126,13 +126,8 @@ DEFAULT_TITLE: Final[str] = "LeadForge: Synthetic B2B Lead Scoring (v1)"
 DEFAULT_SUBTITLE: Final[str] = "Three-tier synthetic CRM funnel for leakage-aware lead scoring"
 
 DEFAULT_KEYWORDS: Final[tuple[str, ...]] = (
-    "b2b",
     "classification",
-    "crm",
     "education",
-    "lead-scoring",
-    "saas",
-    "synthetic-data",
     "tabular",
 )
 

--- a/tests/scripts/test_lint_platform_metadata.py
+++ b/tests/scripts/test_lint_platform_metadata.py
@@ -100,13 +100,8 @@ def _minimal_artifacts() -> tuple[dict[str, object], dict[str, object]]:
         "isPrivate": False,
         "licenses": [{"name": "MIT"}],
         "keywords": [
-            "b2b",
             "classification",
-            "crm",
             "education",
-            "lead-scoring",
-            "saas",
-            "synthetic-data",
             "tabular",
         ],
         "expectedUpdateFrequency": "never",


### PR DESCRIPTION
## Summary

- Removes `b2b`, `crm`, `lead-scoring`, `saas`, `synthetic-data` from `DEFAULT_KEYWORDS` in `package_kaggle_release.py` — Kaggle rejected all five as unknown tags during `dataset_metadata_update`
- Aligns `REQUIRED_COMMON_TAGS` in `lint_platform_metadata.py` to only require tags valid on **both** platforms (only `tabular` survives); HF-specific tags are still enforced by the separate `EXPECTED_HF_TAGS` exact-match check
- Updates test fixture in `test_lint_platform_metadata.py` and regenerates `release/_preview_committed/kaggle.html` golden file

## Context

The Kaggle live dataset (`derelictpanda/leadforge-lead-scoring-v1`) has already had its metadata updated with the correct description, subtitle, MIT license, and cover image. The invalid keywords were silently dropped by the API during that update; this PR makes the source artifacts consistent with what Kaggle actually accepted.

## Test plan

- [x] `pytest tests/scripts/test_lint_platform_metadata.py` — 12 passed
- [x] `pytest tests/scripts/test_preview_kaggle_page.py` — 26 passed
- [x] Full suite: 1482 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)