### PR TITLE
fix(ci): pin scikit-learn<1.9 to restore G13.1 notebook gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,13 @@ dev = [
     "mypy>=1.10",
     "pre-commit>=3.7",
     "types-pyyaml>=6.0",
-    "scikit-learn>=1.3",
+    # scikit-learn 1.9.0 changed HistGradientBoostingClassifier defaults in a
+    # way that improves the flat GBM more than the engineered one, making the
+    # headline GBM(eng)−GBM(flat) lift in NB02 go non-positive and breaking
+    # the G13.1 CI gate.  Pin <1.9 while the notebook targets are recalibrated
+    # or the engineered features are updated to restore positive lift on 1.9.
+    # See: https://github.com/leadforge-dev/leadforge/issues/114
+    "scikit-learn>=1.3,<1.9",
     "matplotlib>=3.7",
     # PR 7.2: the preview-page renderers (scripts/preview_{kaggle,hf}_page.py)
     # call into markdown-it-py at test time via render_*_html().  Keeping
@@ -49,7 +55,7 @@ dev = [
     "markdown-it-py>=3.0",
 ]
 scripts = [
-    "scikit-learn>=1.3",
+    "scikit-learn>=1.3,<1.9",  # keep in sync with [dev] pin above
     "matplotlib>=3.7",
 ]
 # Optional dependencies for the platform release packagers.  Installing
@@ -81,7 +87,7 @@ notebooks = [
     # python3`` because the GitHub-hosted runner has no kernelspecs
     # registered out of the box (local dev environments usually do).
     "ipykernel>=6.0",
-    "scikit-learn>=1.3",
+    "scikit-learn>=1.3,<1.9",  # keep in sync with [dev] pin above
     "matplotlib>=3.7",
 ]
 


### PR DESCRIPTION
## Summary

Restores the failing `Execute release notebooks (G13.1)` CI gate by pinning
`scikit-learn<1.9` in all three relevant extras (`[dev]`, `[scripts]`,
`[notebooks]`). The gate has been failing on every PR since sklearn 1.9.0
shipped, because the uncapped `>=1.3` was resolving to 1.9.0 in CI.

## Root cause

`scikit-learn 1.9.0` changed `HistGradientBoostingClassifier` defaults in a
way that improves the **flat** GBM model substantially while the
**engineered-feature** GBM does not keep pace. In notebook 02
(`02_relational_feature_engineering.ipynb`) this causes the headline
GBM(eng)−GBM(flat) lift to go non-positive, triggering:

```
AssertionError: notebook 02 metric panel (seed 42, intermediate) drifted outside tolerance:
  gbm_flat_auc:      observed=0.6339 target=0.6023 |diff|=0.0316 > tol=0.0200
  headline_lift_auc: observed=-0.0253 target=0.0110 |diff|=0.0363 > tol=0.0150
```

Note: `random_state=SEED` is already set in the notebook's GBM constructor —
the change is deterministic per version, not randomness.

## Fix

Pin `scikit-learn>=1.3,<1.9` in `pyproject.toml` (dev + scripts + notebooks
extras). All three kept in sync with the same upper bound.

## This is a hold, not a resolution

Tracking issue **#114** documents the root cause and the steps to remove the
pin:
1. Identify which 1.9 default changed and whether recalibrating `NB02_TARGETS`
   is appropriate, or whether the relational engineered features need updating to
   restore positive lift on 1.9.
2. Once resolved, widen the bound and recheck all three metrics.

## Testing

- Main test suite: 1544 passed / 46 skipped (all pass at sklearn 1.7.x, the
  pinned local version).
- The G13.1 gate itself can only be verified in CI (requires the pre-built
  release bundles on disk). Confident the pin restores it because the failure
  is deterministically tied to the 1.9.0 version observed in CI logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)